### PR TITLE
Tweaked Jakefile to work on Windows

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -1,5 +1,6 @@
 /*globals jake, desc, task, fail, console */
 
+var path = require('path');
 var jasmine = require('jasmine-node');
 
 desc('Default (build all)');
@@ -10,7 +11,7 @@ task('all', ['lint', 'test', 'min']);
 
 desc('Shake out the lint');
 task('lint', function() {
-    var lint = './node_modules/.bin/jshint',
+    var lint = path.normalize('./node_modules/.bin/jshint'),
         targets = ['Uri.js', 'Jakefile'],
         commands = targets.map(function(target) {
             return lint + ' ' + target;
@@ -23,7 +24,7 @@ task('lint', function() {
 
 desc('Run Jasmine specs');
 task('test', function() {
-    var specDir = './spec';
+    var specDir = path.normalize('./spec');
     console.log('running jasmine tests from', specDir);
     jasmine.executeSpecsInFolder({
         specFolders: [specDir],
@@ -42,7 +43,7 @@ desc('Minify the compiled Uri.js file');
 task('min', function() {
     var source = 'Uri.js',
         target = 'Uri.min.js',
-        command = './node_modules/.bin/uglifyjs ' + source + ' > ' + target;
+        command = path.normalize('./node_modules/.bin/uglifyjs') + ' ' + source + ' > ' + target;
     console.log('minifying', source, 'into', target);
     jake.exec([command], {
         printStdout: true


### PR DESCRIPTION
Using Node's `path.normalize` will automatically use the correct path separators for the current architecture/OS/platform.
