### PR TITLE
Add spm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Uri parsing and manipulation for node.js and the browser.
 
 [![NPM](https://nodei.co/npm/jsuri.png)](https://nodei.co/npm/jsuri/)
 
+[![spm package](http://spmjs.io/badge/jsuri)](http://spmjs.io/package/jsuri)
+
 [![browser support](https://ci.testling.com/derek-watson/jsUri.png)](http://ci.testling.com/derek-watson/jsUri)
 
 Pass any url into the constructor

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "sub"           : false,
     "trailing"      : true,
     "white"         : false
+  },
+  "spm": {
+    "main": "Uri.js"
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/jsuri

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of jsuri in spmjs, I can add it for your account after signing in http://spmjs.io.
