### PR TITLE
replaceQueryParam() with three arguments adds newVal when oldVal missing

### DIFF
--- a/Uri.js
+++ b/Uri.js
@@ -260,7 +260,9 @@
           break;
         }
       }
-      this.deleteQueryParam(key, decode(oldVal)).addQueryParam(key, newVal, index);
+      if (index >= 0) {
+        this.deleteQueryParam(key, decode(oldVal)).addQueryParam(key, newVal, index);
+      }
     } else {
       for (i = 0; i < this.queryPairs.length; i++) {
         param = this.queryPairs[i];

--- a/test/uri/query.js
+++ b/test/uri/query.js
@@ -138,7 +138,7 @@ describe('Uri', function() {
 
       it('should be able to replace a param value with a specified value that does not exist', function() {
         q = new Uri('?page=4&page=2').replaceQueryParam('page', 3, 1)
-        expect(q.toString()).to.equal('?page=4&page=2&page=3')
+        expect(q.toString()).to.equal('?page=4&page=2')
       })
 
       it('should be able to handle multiple values for the same key', function() {


### PR DESCRIPTION
I noticed that replaceQueryParam() called with three arguments adds the new value even [when the old value is not found.](https://github.com/johnmarkos/jsUri/commit/762fd9714edaeab59c0c47e2975a7caf4fc14581) Is this expected behavior?
