### PR TITLE
Proper forEach polyfill

### DIFF
--- a/Uri.js
+++ b/Uri.js
@@ -28,9 +28,33 @@
    * @see https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Array/forEach#Compatibility
    */
   if (!Array.prototype.forEach) {
-    Array.prototype.forEach = function(fn, scope) {
-      for (var i = 0, len = this.length; i < len; ++i) {
-        fn.call(scope || this, this[i], i, this);
+    Array.prototype.forEach = function(callback, thisArg) {
+      var T, k;
+
+      if (this == null) {
+        throw new TypeError(' this is null or not defined');
+      }
+
+      var O = Object(this);
+      var len = O.length >>> 0;
+
+      if (typeof callback !== "function") {
+        throw new TypeError(callback + ' is not a function');
+      }
+
+      if (arguments.length > 1) {
+        T = thisArg;
+      }
+
+      k = 0;
+
+      while (k < len) {
+        var kValue;
+        if (k in O) {
+          kValue = O[k];
+          callback.call(T, kValue, k, O);
+        }
+        k++;
       }
     };
   }


### PR DESCRIPTION
The listed polyfill did not handle all cases, such as `null` or callbacks that are not of type `function`. This is the proper implementation as defined by the MDN.
