### PR TITLE
Remove unreachable case: no leading question mark.

### DIFF
--- a/Uri.js
+++ b/Uri.js
@@ -400,9 +400,6 @@
       }
     }
     if (this.query().toString()) {
-      if (this.query().toString().indexOf('?') !== 0) {
-        s += '?';
-      }
       s += this.query().toString();
     }
 


### PR DESCRIPTION
I was trying to cover the removed lines 403-405, where this.query().toString() is checked for a missing leading question mark. It looks to me as though this case is unreachable, because Uri.prototype.query() adds a leading question mark to a non-empty string.

I suggest removing the unreachable condition.
