### PR TITLE
Replace Chai by standard assert

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   "devDependencies": {
     "jshint": "~2.1.11",
     "uglify-js": "~2.4.0",
-    "mocha": "~1.14.0",
-    "chai": "~1.9.2"
+    "mocha": "~1.14.0"
   },
   "optionalDependencies": {},
   "engines": {

--- a/test/uri.js
+++ b/test/uri.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect
+var assert = require("assert")
 
 var Uri = (typeof(require) === 'function') ? require('../Uri') : window.Uri
 
@@ -11,213 +11,213 @@ describe('Uri', function() {
 
   it('can replace protocol', function() {
     u.protocol('https')
-    expect(u.toString()).to.equal('https://test.com')
+    assert.equal(u.toString(), 'https://test.com');
   })
 
   it('can replace protocol with colon suffix', function() {
     u.protocol('https:')
-    expect(u.toString()).to.equal('https://test.com')
+    assert.equal(u.toString(), 'https://test.com')
   })
 
   it('keeps authority prefix when protocol is removed', function() {
     u.protocol(null)
-    expect(u.toString()).to.equal('//test.com')
+    assert.equal(u.toString(), '//test.com')
   })
 
   it('can disable authority prefix but keep protocol', function() {
     u.hasAuthorityPrefix(false)
-    expect(u.toString()).to.equal('http://test.com')
+    assert.equal(u.toString(), 'http://test.com')
   })
 
   it('can add user info', function() {
     u.userInfo('username:password')
-    expect(u.toString()).to.equal('http://username:password@test.com')
+    assert.equal(u.toString(), 'http://username:password@test.com')
   })
 
   it('can add user info with trailing at', function() {
     u.userInfo('username:password@')
-    expect(u.toString()).to.equal('http://username:password@test.com')
+    assert.equal(u.toString(), 'http://username:password@test.com')
   })
 
   it('can add a hostname to a relative path', function() {
     u = new Uri('/index.html')
     u.host('wherever.com')
-    expect(u.toString()).to.equal('wherever.com/index.html')
+    assert.equal(u.toString(), 'wherever.com/index.html')
   })
 
   it('can change a hostname ', function() {
     u.host('wherever.com')
-    expect(u.toString()).to.equal('http://wherever.com')
+    assert.equal(u.toString(), 'http://wherever.com')
   })
 
   it('should not add a port when there is no hostname', function() {
     u = new Uri('/index.html')
     u.port(8080)
-    expect(u.toString()).to.equal('/index.html')
+    assert.equal(u.toString(), '/index.html')
   })
 
   it('should be able to change the port', function() {
     u.port(8080)
-    expect(u.toString()).to.equal('http://test.com:8080')
+    assert.equal(u.toString(), 'http://test.com:8080')
   })
 
   it('should be able to add a path to a domain', function() {
     u = new Uri('test.com')
     u.path('/some/article.html')
-    expect(u.toString()).to.equal('test.com/some/article.html')
+    assert.equal(u.toString(), 'test.com/some/article.html')
   })
 
   it('should be able to change a path', function() {
     u.path('/some/article.html')
-    expect(u.toString()).to.equal('http://test.com/some/article.html')
+    assert.equal(u.toString(), 'http://test.com/some/article.html')
   })
 
   it('should be able to delete a path', function() {
     u = new Uri('http://test.com/index.html')
     u.path(null)
-    expect(u.toString()).to.equal('http://test.com')
+    assert.equal(u.toString(), 'http://test.com')
   })
 
   it('should be able to empty a path', function() {
     u = new Uri('http://test.com/index.html')
     u.path('')
-    expect(u.toString()).to.equal('http://test.com')
+    assert.equal(u.toString(), 'http://test.com')
   })
 
   it('should be able to add a query to nothing', function() {
     u = new Uri('')
     u.query('this=that&something=else')
-    expect(u.toString()).to.equal('?this=that&something=else')
+    assert.equal(u.toString(), '?this=that&something=else')
   })
 
   it('should be able to add a query to a relative path', function() {
     u = new Uri('/some/file.html')
     u.query('this=that&something=else')
-    expect(u.toString()).to.equal('/some/file.html?this=that&something=else')
+    assert.equal(u.toString(), '/some/file.html?this=that&something=else')
   })
 
   it('should be able to add a query to a domain', function() {
     u = new Uri('test.com')
     u.query('this=that&something=else')
-    expect(u.toString()).to.equal('test.com/?this=that&something=else')
+    assert.equal(u.toString(), 'test.com/?this=that&something=else')
   })
 
   it('should be able to swap a query', function() {
     u = new Uri('www.test.com?this=that&a=1&b=2c=3')
     u.query('this=that&something=else')
-    expect(u.toString()).to.equal('www.test.com/?this=that&something=else')
+    assert.equal(u.toString(), 'www.test.com/?this=that&something=else')
   })
 
   it('should be able to delete a query', function() {
     u = new Uri('www.test.com?this=that&a=1&b=2c=3')
     u.query(null)
-    expect(u.toString()).to.equal('www.test.com')
+    assert.equal(u.toString(), 'www.test.com')
   })
 
   it('should be able to empty a query', function() {
     u = new Uri('www.test.com?this=that&a=1&b=2c=3')
     u.query('')
-    expect(u.toString()).to.equal('www.test.com')
+    assert.equal(u.toString(), 'www.test.com')
   })
 
   it('should be able to add an anchor to a domain', function() {
     u = new Uri('test.com')
     u.anchor('content')
-    expect(u.toString()).to.equal('test.com/#content')
+    assert.equal(u.toString(), 'test.com/#content')
   })
 
   it('should be able to add an anchor with a hash prefix to a domain', function() {
     u = new Uri('test.com')
     u.anchor('#content')
-    expect(u.toString()).to.equal('test.com/#content')
+    assert.equal(u.toString(), 'test.com/#content')
   })
 
   it('should be able to add an anchor to a path', function() {
     u = new Uri('a/b/c/123.html')
     u.anchor('content')
-    expect(u.toString()).to.equal('a/b/c/123.html#content')
+    assert.equal(u.toString(), 'a/b/c/123.html#content')
   })
 
   it('should be able to change an anchor', function() {
     u = new Uri('/a/b/c/index.html#content')
     u.anchor('about')
-    expect(u.toString()).to.equal('/a/b/c/index.html#about')
+    assert.equal(u.toString(), '/a/b/c/index.html#about')
   })
 
   it('should be able to empty an anchor', function() {
     u = new Uri('/a/b/c/index.html#content')
     u.anchor('')
-    expect(u.toString()).to.equal('/a/b/c/index.html')
+    assert.equal(u.toString(), '/a/b/c/index.html')
   })
 
   it('should be able to delete an anchor', function() {
     u = new Uri('/a/b/c/index.html#content')
     u.anchor(null)
-    expect(u.toString()).to.equal('/a/b/c/index.html')
+    assert.equal(u.toString(), '/a/b/c/index.html')
   })
 
   it('should be able to get single encoded values', function() {
     u = new Uri('http://example.com/search?q=%40')
-    expect(u.getQueryParamValue('q')).to.equal('@')
+    assert.equal(u.getQueryParamValue('q'), '@')
   })
 
   it('should be able to get double encoded values', function() {
     u = new Uri('http://example.com/search?q=%2540')
-    expect(u.getQueryParamValue('q')).to.equal('%40')
+    assert.equal(u.getQueryParamValue('q'), '%40')
   })
 
   it('should be able to work with %40 values', function() {
     u = new Uri('http://example.com/search?q=%40&stupid=yes')
     u.deleteQueryParam('stupid')
-    expect(u.toString()).to.equal('http://example.com/search?q=%40')
+    assert.equal(u.toString(), 'http://example.com/search?q=%40')
   })
 
   it('should be able to work with %25 values', function() {
     u = new Uri('http://example.com/search?q=100%25&stupid=yes')
     u.deleteQueryParam('stupid')
-    expect(u.toString()).to.equal('http://example.com/search?q=100%25')
+    assert.equal(u.toString(), 'http://example.com/search?q=100%25')
   })
 
   it('should insert missing slash when origin and path have no slash', function () {
     u = new Uri('http://test.com')
     u.setPath('relativePath')
-    expect(u.toString()).to.equal('http://test.com/relativePath')
+    assert.equal(u.toString(), 'http://test.com/relativePath')
   })
 
   it('should remove extra slash when origin and path both provide a slash', function () {
     u = new Uri('http://test.com/')
     u.setPath('/relativePath')
-    expect(u.toString()).to.equal('http://test.com/relativePath')
+    assert.equal(u.toString(), 'http://test.com/relativePath')
   })
 
   it('should remove extra slashes when origin and path both provide too many slashes', function () {
     u = new Uri('http://test.com//')
     u.setPath('//relativePath')
-    expect(u.toString()).to.equal('http://test.com/relativePath')
+    assert.equal(u.toString(), 'http://test.com/relativePath')
   })
 
   it('should be able to clone a separate copy which does not share state', function() {
     var a = new Uri('?a=1'),
         b = a.clone().addQueryParam('b', '2')
-    expect(a.toString()).to.not.equal(b.toString())
+    assert.notEqual(a.toString(), b.toString())
   })
 
   it('can add a trailing slash to the path', function() {
     var str = new Uri('http://www.example.com/path?arr=1&arr=2')
       .addTrailingSlash()
       .toString()
-    expect(str).to.equal('http://www.example.com/path/?arr=1&arr=2')
+    assert.equal(str, 'http://www.example.com/path/?arr=1&arr=2')
   })
 
   it('preserves the format of file uris', function() {
     var str = 'file://c:/parent/child.ext'
     var uri = new Uri(str)
-    expect(uri.toString()).to.equal(str)
+    assert.equal(uri.toString(), str)
   })
 
   it('correctly composes url encoded urls', function() {
      var originalQuery = '?k=%40v'
      var parsed = new Uri('http://example.com' + originalQuery)
-     expect(parsed.query()).to.equal(originalQuery)
+     assert.equal(parsed.query(), originalQuery)
   })
 })

--- a/test/uri/fluent-setters.js
+++ b/test/uri/fluent-setters.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect
+var assert = require("assert");
 
 var Uri = (typeof(require) === 'function') ? require('../../Uri') : window.Uri
 
@@ -10,14 +10,14 @@ describe('Uri', function() {
       u = new Uri('www.yahoo.com')
         .setPath('/index.html')
         .setAnchor('content')
-      expect(u.toString()).to.equal('www.yahoo.com/index.html#content')
+      assert.equal(u.toString(), 'www.yahoo.com/index.html#content')
     })
 
     it('can fluently replace host and protocol', function() {
       u = new Uri('www.yahoo.com/index.html')
         .setHost('test.com')
         .setProtocol('https')
-      expect(u.toString()).to.equal('https://test.com/index.html')
+      assert.equal(u.toString(), 'https://test.com/index.html')
     })
 
     it('can fluently construct a url out of nothing', function() {
@@ -29,7 +29,7 @@ describe('Uri', function() {
         .setUserInfo('username:password')
         .setProtocol('https')
         .setQuery('this=that&some=thing')
-      expect(u.toString()).to.equal('https://username:password@www.test.com:8080/index.html?this=that&some=thing#content')
+      assert.equal(u.toString(), 'https://username:password@www.test.com:8080/index.html?this=that&some=thing#content')
     })
 
     it('can fluently destroy all parts of a url', function() {
@@ -41,7 +41,7 @@ describe('Uri', function() {
         .setUserInfo(null)
         .setProtocol(null)
         .setQuery(null)
-      expect(u.toString()).to.equal('')
+      assert.equal(u.toString(), '')
     })
   })
 })

--- a/test/uri/query.js
+++ b/test/uri/query.js
@@ -1,4 +1,4 @@
-var expect = require('chai').expect
+var assert = require('assert');
 
 var Uri = (typeof(require) === 'function') ? require('../../Uri') : window.Uri
 
@@ -7,7 +7,7 @@ describe('Uri', function() {
 
     it('correctly parses query param expressions with multiple = separators', function() {
       var back = new Uri('?back=path/to/list?page=1').getQueryParamValue('back')
-      expect(back).to.equal('path/to/list?page=1')
+      assert.equal(back, 'path/to/list?page=1')
     })
 
     describe('construction', function() {
@@ -15,35 +15,35 @@ describe('Uri', function() {
 
       it('should decode entities when parsing', function(){
         q = new Uri('?email=user%40example.com')
-        expect(q.getQueryParamValue('email')).to.equal('user@example.com')
+        assert.equal(q.getQueryParamValue('email'), 'user@example.com')
       })
 
       it('should include an equal sign if there was one present without a query value', function() {
         q = new Uri('?11=')
-        expect(q.toString()).to.equal('?11=')
+        assert.equal(q.toString(), '?11=')
       })
 
       it('should not include an equal sign if one was not present originally', function() {
         q = new Uri('?11')
-        expect(q.toString()).to.equal('?11')
+        assert.equal(q.toString(), '?11')
       })
 
       it('should preserve missing equals signs across many keys', function() {
         q = new Uri('?11&12&13&14')
-        expect(q.toString()).to.equal('?11&12&13&14')
+        assert.equal(q.toString(), '?11&12&13&14')
       })
 
       it('should preserve missing equals signs in a mixed scenario', function() {
         q = new Uri('?11=eleven&12=&13&14=fourteen')
-        expect(q.toString()).to.equal('?11=eleven&12=&13&14=fourteen')
+        assert.equal(q.toString(), '?11=eleven&12=&13&14=fourteen')
       })
 
       it('should correctly parse the uri if an @ sign is present after the host part of the url', function(){
         q = new Uri('http://github.com/username?email=user@example.com&11=eleven')
-        expect(q.host()).to.equal('github.com')
-        expect(q.path()).to.equal('/username')
-        expect(q.getQueryParamValue('email')).to.equal('user@example.com')
-        expect(q.getQueryParamValue('11')).to.equal('eleven')
+        assert.equal(q.host(), 'github.com')
+        assert.equal(q.path(), '/username')
+        assert.equal(q.getQueryParamValue('email'), 'user@example.com')
+        assert.equal(q.getQueryParamValue('11'), 'eleven')
       })
     })
 
@@ -52,141 +52,141 @@ describe('Uri', function() {
 
       it('should return the first value for each query param', function() {
         q = new Uri('?a=1&a=2&b=3&b=4&c=567')
-        expect(q.getQueryParamValue('a')).to.equal('1')
-        expect(q.getQueryParamValue('b')).to.equal('3')
-        expect(q.getQueryParamValue('c')).to.equal('567')
+        assert.equal(q.getQueryParamValue('a'), '1')
+        assert.equal(q.getQueryParamValue('b'), '3')
+        assert.equal(q.getQueryParamValue('c'), '567')
       })
 
       it('should return arrays for multi-valued query params', function() {
         q = new Uri('?a=1&a=2&b=3&b=4&c=567')
-        expect(q.getQueryParamValues('a')[0]).to.equal('1')
-        expect(q.getQueryParamValues('a')[1]).to.equal('2')
-        expect(q.getQueryParamValues('b')[0]).to.equal('3')
-        expect(q.getQueryParamValues('b')[1]).to.equal('4')
-        expect(q.getQueryParamValues('c')[0]).to.equal('567')
+        assert.equal(q.getQueryParamValues('a')[0], '1')
+        assert.equal(q.getQueryParamValues('a')[1], '2')
+        assert.equal(q.getQueryParamValues('b')[0], '3')
+        assert.equal(q.getQueryParamValues('b')[1], '4')
+        assert.equal(q.getQueryParamValues('c')[0], '567')
       })
 
       it('should be able to add a new query param to a blank url', function() {
         q = new Uri('').addQueryParam('q', 'books')
-        expect(q.toString()).to.equal('?q=books')
+        assert.equal(q.toString(), '?q=books')
       })
 
       it('should be able to delete a query param', function() {
         q = new Uri('?a=1&b=2&c=3&a=eh').deleteQueryParam('b')
-        expect(q.toString()).to.equal('?a=1&c=3&a=eh')
+        assert.equal(q.toString(), '?a=1&c=3&a=eh')
       })
 
       it('should be able to delete a query param by value', function() {
         q = new Uri('?a=1&b=2&c=3&a=eh').deleteQueryParam('a', 'eh')
-        expect(q.toString()).to.equal('?a=1&b=2&c=3')
+        assert.equal(q.toString(), '?a=1&b=2&c=3')
       })
 
       it('should be able to add a null param', function() {
         q = new Uri('?a=1&b=2&c=3').addQueryParam('d')
-        expect(q.toString()).to.equal('?a=1&b=2&c=3&d=')
+        assert.equal(q.toString(), '?a=1&b=2&c=3&d=')
       })
 
       it('should be able to add a key and a value', function() {
         q = new Uri('?a=1&b=2&c=3').addQueryParam('d', '4')
-        expect(q.toString()).to.equal('?a=1&b=2&c=3&d=4')
+        assert.equal(q.toString(), '?a=1&b=2&c=3&d=4')
       })
 
       it('should be able to prepend a key and a value', function() {
         q = new Uri('?a=1&b=2&c=3').addQueryParam('d', '4', 0)
-        expect(q.toString()).to.equal('?d=4&a=1&b=2&c=3')
+        assert.equal(q.toString(), '?d=4&a=1&b=2&c=3')
       })
 
       it('should return query param values correctly', function() {
         q = new Uri('').addQueryParam('k', 'value@example.com')
-        expect(q.getQueryParamValue('k')).to.equal('value@example.com')
+        assert.equal(q.getQueryParamValue('k'), 'value@example.com')
       })
 
       it('should escape param values correctly', function() {
         q = new Uri('http://example.com').addQueryParam('k', 'user@example.org')
-        expect(q.toString()).to.equal('http://example.com/?k=user%40example.org')
+        assert.equal(q.toString(), 'http://example.com/?k=user%40example.org')
       })
 
       it('should be able to delete and replace a query param', function() {
         q = new Uri('?a=1&b=2&c=3').deleteQueryParam('a').addQueryParam('a', 'eh')
-        expect(q.toString()).to.equal('?b=2&c=3&a=eh')
+        assert.equal(q.toString(), '?b=2&c=3&a=eh')
       })
 
       it('should not do anything if passed no params', function() {
         q = new Uri('?a=1&b=2&c=3').addQueryParam()
-        expect(q.toString()).to.equal('?a=1&b=2&c=3')
+        assert.equal(q.toString(), '?a=1&b=2&c=3')
       })
 
       it('should be able to directly replace a query param', function() {
         q = new Uri('?a=1&b=2&c=3').replaceQueryParam('a', 'eh')
-        expect(q.toString()).to.equal('?a=eh&b=2&c=3')
+        assert.equal(q.toString(), '?a=eh&b=2&c=3')
       })
 
       it('should remove an extra question mark', function() {
         q = new Uri('??a=1&b=2&c=3').replaceQueryParam('a', 4)
-        expect(q.toString()).to.equal('?a=4&b=2&c=3')
+        assert.equal(q.toString(), '?a=4&b=2&c=3')
       })
 
       it('should remove a param without a key', function() {
         q = new Uri('?=1&b=2&c=3').replaceQueryParam('a', 4)
-        expect(q.toString()).to.equal('?b=2&c=3&a=4')
+        assert.equal(q.toString(), '?b=2&c=3&a=4')
       })
 
       it('should be able to replace a query param value that does not exist', function() {
         q = new Uri().replaceQueryParam('page', 2)
-        expect(q.toString()).to.equal('?page=2')
+        assert.equal(q.toString(), '?page=2')
       })
 
       it('should be able to replace a nonexistent query param value when others exist', function() {
         q = new Uri('?a=1').replaceQueryParam('page', 2)
-        expect(q.toString()).to.equal('?a=1&page=2')
+        assert.equal(q.toString(), '?a=1&page=2')
       })
 
       it('should be able to replace only a query param value with a specified value', function() {
         q = new Uri('?page=1&page=2').replaceQueryParam('page', 3, 1)
-        expect(q.toString()).to.equal('?page=3&page=2')
+        assert.equal(q.toString(), '?page=3&page=2')
       })
 
       it('should be able to replace only a query param value with a specified string value', function() {
         q = new Uri('?a=one&a=two').replaceQueryParam('a', 'three', 'one')
-        expect(q.toString()).to.equal('?a=three&a=two')
+        assert.equal(q.toString(), '?a=three&a=two')
       })
 
       it('should be able to replace a param value with a specified value that does not exist', function() {
         q = new Uri('?page=4&page=2').replaceQueryParam('page', 3, 1)
-        expect(q.toString()).to.equal('?page=4&page=2')
+        assert.equal(q.toString(), '?page=4&page=2')
       })
 
       it('should replace a param value with an empty value if not provided a value', function() {
         q = new Uri('?page=4&page=2').replaceQueryParam('page')
-        expect(q.toString()).to.equal('?page=')
+        assert.equal(q.toString(), '?page=')
       })
 
       it('should be able to handle multiple values for the same key', function() {
         q = new Uri().addQueryParam('a', 1)
-        expect(q.toString()).to.equal('?a=1')
-        expect(q.getQueryParamValues('a').length).to.equal(1)
+        assert.equal(q.toString(), '?a=1')
+        assert.equal(q.getQueryParamValues('a').length, 1)
         q.addQueryParam('a', 2)
-        expect(q.toString()).to.equal('?a=1&a=2')
-        expect(q.getQueryParamValues('a').length).to.equal(2)
+        assert.equal(q.toString(), '?a=1&a=2')
+        assert.equal(q.getQueryParamValues('a').length, 2)
         q.addQueryParam('a', 3)
-        expect(q.toString()).to.equal('?a=1&a=2&a=3')
-        expect(q.getQueryParamValues('a').length).to.equal(3)
+        assert.equal(q.toString(), '?a=1&a=2&a=3')
+        assert.equal(q.getQueryParamValues('a').length, 3)
         q.deleteQueryParam('a', 2)
-        expect(q.toString()).to.equal('?a=1&a=3')
-        expect(q.getQueryParamValues('a').length).to.equal(2)
+        assert.equal(q.toString(), '?a=1&a=3')
+        assert.equal(q.getQueryParamValues('a').length, 2)
         q.deleteQueryParam('a')
-        expect(q.toString()).to.equal('')
-        expect(q.getQueryParamValues('a').length).to.equal(0)
+        assert.equal(q.toString(), '')
+        assert.equal(q.getQueryParamValues('a').length, 0)
       })
 
       it('should not add a trailing slash if one is already present', function () {
         q = new Uri('stuff/').addTrailingSlash();
-        expect(q.toString()).to.equal('stuff/')
+        assert.equal(q.toString(), 'stuff/')
       })
 
       it('should add a trailing slash to an empty uri', function () {
         q = new Uri().addTrailingSlash();
-        expect(q.toString()).to.equal('/')
+        assert.equal(q.toString(), '/')
       })
     })
 
@@ -195,12 +195,12 @@ describe('Uri', function() {
 
       it('should replace semicolons with ampersands', function() {
         q = new Uri('?one=1;two=2;three=3')
-        expect(q.toString()).to.equal('?one=1&two=2&three=3')
+        assert.equal(q.toString(), '?one=1&two=2&three=3')
       })
 
       it('should replace semicolons with ampersands, delete the first param and add another', function() {
         q = new Uri('?one=1;two=2;three=3&four=4').deleteQueryParam('one').addQueryParam('test', 'val', 1)
-        expect(q.toString()).to.equal('?two=2&test=val&three=3&four=4')
+        assert.equal(q.toString(), '?two=2&test=val&three=3&four=4')
       })
     })
 
@@ -209,42 +209,42 @@ describe('Uri', function() {
 
       it('is able to find the value of an encoded multiword key from a non encoded search', function() {
         q = new Uri('?a=1&this%20is%20a%20multiword%20key=value&c=3')
-        expect(q.getQueryParamValue('this is a multiword key')).to.equal('value')
+        assert.equal(q.getQueryParamValue('this is a multiword key'), 'value')
       })
 
       it('is able to on the fly decode an encoded param value', function() {
         q = new Uri('?a=1&b=this%20is%20a%20multiword%20val&c=3')
-        expect(q.getQueryParamValue('b')).to.equal('this is a multiword val')
+        assert.equal(q.getQueryParamValue('b'), 'this is a multiword val')
       })
 
       it('is able to on the fly decode a space-encoded param value', function() {
         q = new Uri('?a=1&b=this is a multiword value&c=3')
-        expect(q.getQueryParamValue('b')).to.equal('this is a multiword value')
+        assert.equal(q.getQueryParamValue('b'), 'this is a multiword value')
       })
 
       it('is able to on the fly decode a double-encoded param value', function() {
         q = new Uri('?a=1&b=this%2520is%2520a%2520multiword%2520value&c=3')
-        expect(q.getQueryParamValue('b')).to.equal('this%20is%20a%20multiword%20value')
+        assert.equal(q.getQueryParamValue('b'), 'this%20is%20a%20multiword%20value')
       })
 
       it('is able to find all value s of an encoded multiword key from a non encoded search', function() {
         q = new Uri('?a=1&this%20is%20a%20multiword%20key=value&c=3')
-        expect(q.getQueryParamValues('this is a multiword key')[0]).to.equal('value')
+        assert.equal(q.getQueryParamValues('this is a multiword key')[0], 'value')
       })
 
       it('is be able to delete a multiword encoded key', function() {
         q = new Uri('?a=1&this%20is%20a%20multiword%20key=value&c=3').deleteQueryParam('this is a multiword key')
-        expect(q.toString()).to.equal('?a=1&c=3')
+        assert.equal(q.toString(), '?a=1&c=3')
       })
 
       it('is able to replace a multiword query param', function() {
         q = new Uri('?this is a multiword key=1').replaceQueryParam('this%20is%20a%20multiword%20key', 2)
-        expect(q.toString()).to.equal('?this%20is%20a%20multiword%20key=2')
+        assert.equal(q.toString(), '?this%20is%20a%20multiword%20key=2')
       })
 
       it('should be able to search for a plus-separated word pair', function() {
         q = new Uri('?multi+word+key=true').replaceQueryParam('multi word key', 2)
-        expect(q.toString()).to.equal('?multi word key=2')
+        assert.equal(q.toString(), '?multi word key=2')
       })
     })
   })

--- a/test/uri/to-string.js
+++ b/test/uri/to-string.js
@@ -1,115 +1,115 @@
-var expect = require('chai').expect
+var assert = require('assert');
 
 var Uri = (typeof(require) === 'function') ? require('../../Uri') : window.Uri
 
 describe('Uri', function() {
   describe('toString()', function() {
     it('should convert empty constructor call to blank url', function() {
-      expect(new Uri().toString()).to.equal('')
+      assert.equal(new Uri().toString(), '')
     })
 
     it('can construct empty string', function() {
-      expect(new Uri().toString()).to.equal('')
+      assert.equal(new Uri().toString(), '')
     })
 
     it('can construct single slash', function() {
-      expect(new Uri('/').toString()).to.equal('/')
+      assert.equal(new Uri('/').toString(), '/')
     })
 
     it('can construct a relative path with a trailing slash', function() {
-      expect(new Uri('tutorial1/').toString()).to.equal('tutorial1/')
+      assert.equal(new Uri('tutorial1/').toString(), 'tutorial1/')
     })
 
     it('can construct a relative path with leading and trailing slashes', function() {
-      expect(new Uri('/experts/').toString()).to.equal('/experts/')
+      assert.equal(new Uri('/experts/').toString(), '/experts/')
     })
 
     it('can construct a relative filename with leading slash', function() {
-      expect(new Uri('/index.html').toString()).to.equal('/index.html')
+      assert.equal(new Uri('/index.html').toString(), '/index.html')
     })
 
     it('can construct a relative directory and filename', function() {
-      expect(new Uri('tutorial1/2.html').toString()).to.equal('tutorial1/2.html')
+      assert.equal(new Uri('tutorial1/2.html').toString(), 'tutorial1/2.html')
     })
 
     it('can construct a relative parent directory', function() {
-      expect(new Uri('../').toString()).to.equal('../')
+      assert.equal(new Uri('../').toString(), '../')
     })
 
     it('can construct a relative great grandparent directory', function() {
-      expect(new Uri('../../../').toString()).to.equal('../../../')
+      assert.equal(new Uri('../../../').toString(), '../../../')
     })
 
     it('can construct a relative current directory', function() {
-      expect(new Uri('./').toString()).to.equal('./')
+      assert.equal(new Uri('./').toString(), './')
     })
 
     it('can construct a relative current directory sibling doc', function() {
-      expect(new Uri('./index.html').toString()).to.equal('./index.html')
+      assert.equal(new Uri('./index.html').toString(), './index.html')
     })
 
     it('can construct a simple three level domain', function() {
-      expect(new Uri('www.example.com').toString()).to.equal('www.example.com')
+      assert.equal(new Uri('www.example.com').toString(), 'www.example.com')
     })
 
     it('can construct a simple absolute url', function() {
-      expect(new Uri('http://www.example.com/index.html').toString()).to.equal('http://www.example.com/index.html')
+      assert.equal(new Uri('http://www.example.com/index.html').toString(), 'http://www.example.com/index.html')
     })
 
     it('can construct a secure absolute url', function() {
-      expect(new Uri('https://www.example.com/index.html').toString()).to.equal('https://www.example.com/index.html')
+      assert.equal(new Uri('https://www.example.com/index.html').toString(), 'https://www.example.com/index.html')
     })
 
     it('can construct a simple url with a custom port', function() {
-      expect(new Uri('http://www.example.com:8080/index.html').toString()).to.equal('http://www.example.com:8080/index.html')
+      assert.equal(new Uri('http://www.example.com:8080/index.html').toString(), 'http://www.example.com:8080/index.html')
     })
 
     it('can construct a secure url with a custom port', function() {
-      expect(new Uri('https://www.example.com:4433/index.html').toString()).to.equal('https://www.example.com:4433/index.html')
+      assert.equal(new Uri('https://www.example.com:4433/index.html').toString(), 'https://www.example.com:4433/index.html')
     })
 
     it('can construct a relative path with a hash part', function() {
-      expect(new Uri('/index.html#about').toString()).to.equal('/index.html#about')
+      assert.equal(new Uri('/index.html#about').toString(), '/index.html#about')
     })
 
     it('can construct a relative path with a hash part', function() {
-      expect(new Uri('/index.html#about').toString()).to.equal('/index.html#about')
+      assert.equal(new Uri('/index.html#about').toString(), '/index.html#about')
     })
 
     it('can construct an absolute path with a hash part', function() {
-      expect(new Uri('http://example.com/index.html#about').toString()).to.equal('http://example.com/index.html#about')
+      assert.equal(new Uri('http://example.com/index.html#about').toString(), 'http://example.com/index.html#about')
     })
 
     it('can construct a relative path with a query string', function() {
-      expect(new Uri('/index.html?a=1&b=2').toString()).to.equal('/index.html?a=1&b=2')
+      assert.equal(new Uri('/index.html?a=1&b=2').toString(), '/index.html?a=1&b=2')
     })
 
     it('can construct an absolute path with a query string', function() {
-      expect(new Uri('http://www.test.com/index.html?a=1&b=2').toString()).to.equal('http://www.test.com/index.html?a=1&b=2')
+      assert.equal(new Uri('http://www.test.com/index.html?a=1&b=2').toString(), 'http://www.test.com/index.html?a=1&b=2')
     })
 
     it('can construct an absolute path with a query string and hash', function() {
-      expect(new Uri('http://www.test.com/index.html?a=1&b=2#a').toString()).to.equal('http://www.test.com/index.html?a=1&b=2#a')
+      assert.equal(new Uri('http://www.test.com/index.html?a=1&b=2#a').toString(), 'http://www.test.com/index.html?a=1&b=2#a')
     })
 
     it('can construct a url with multiple synonymous query values', function() {
-      expect(new Uri('http://www.test.com/index.html?arr=1&arr=2&arr=3&arr=3&b=2').toString()).to.equal('http://www.test.com/index.html?arr=1&arr=2&arr=3&arr=3&b=2')
+      assert.equal(new Uri('http://www.test.com/index.html?arr=1&arr=2&arr=3&arr=3&b=2').toString(), 'http://www.test.com/index.html?arr=1&arr=2&arr=3&arr=3&b=2')
     })
 
     it('can construct a url with blank query value', function() {
-      expect(new Uri('http://www.test.com/index.html?arr=1&arr=&arr=2').toString()).to.equal('http://www.test.com/index.html?arr=1&arr=&arr=2')
+      assert.equal(new Uri('http://www.test.com/index.html?arr=1&arr=&arr=2').toString(), 'http://www.test.com/index.html?arr=1&arr=&arr=2')
     })
 
     it('can construct a url without a scheme', function() {
-      expect(new Uri('//www.test.com/').toString()).to.equal('//www.test.com/')
+      assert.equal(new Uri('//www.test.com/').toString(), '//www.test.com/')
     })
 
     it('can construct a path and single query kvp', function() {
-      expect(new Uri('/contacts?name=m').toString()).to.equal('/contacts?name=m')
+      assert.equal(new Uri('/contacts?name=m').toString(), '/contacts?name=m')
     })
 
     it('returns successfully returns the origin with a scheme, auth, host and port', function() {
-      expect(new Uri('http://me:here@test.com:81/this/is/a/path').origin()).to.equal('http://me:here@test.com:81')
+      assert.equal(new Uri('http://me:here@test.com:81/this/is/a/path').origin(), 'http://me:here@test.com:81')
     })
   })
 })


### PR DESCRIPTION
Actualy npm install --dev trhow many warnings. Chai is not usefull here, so I suggest to replace it by standard node assert module.