### PR TITLE
[WIP] Add caseSensitive option for query param keys matching

### DIFF
--- a/Uri.js
+++ b/Uri.js
@@ -132,6 +132,7 @@
     this.uriParts = parseUri(str);
     this.queryPairs = parseQuery(this.uriParts.query);
     this.hasAuthorityPrefixUserPref = null;
+    this.isCaseSensitive = true;
   }
 
   /**
@@ -161,6 +162,16 @@
     } else {
       return this.hasAuthorityPrefixUserPref;
     }
+  };
+
+  /**
+   * Sets case sensitivity for matching query params keys.
+   * @param  {Boolean}  val
+   * @return {Uri}
+   */
+  Uri.prototype.caseSensitive = function(val) {
+    this.isCaseSensitive = val;
+    return this;
   };
 
   Uri.prototype.isColonUri = function (val) {
@@ -210,7 +221,11 @@
     var param, i, l;
     for (i = 0, l = this.queryPairs.length; i < l; i++) {
       param = this.queryPairs[i];
-      if (key === param[0]) {
+      if (this.isCaseSensitive) {
+        if (key === param[0]) {
+          return param[1];
+        }
+      } else if (key.toLowerCase() === param[0].toLowerCase()) {
         return param[1];
       }
     }
@@ -225,8 +240,12 @@
     var arr = [], i, param, l;
     for (i = 0, l = this.queryPairs.length; i < l; i++) {
       param = this.queryPairs[i];
-      if (key === param[0]) {
-        arr.push(param[1]);
+      if (this.isCaseSensitive) {
+        if (key === param[0]) {
+          arr.push(param[1]);
+        }
+      } else if (key.toLowerCase() === param[0].toLowerCase()) {
+          arr.push(param[1]);
       }
     }
     return arr;

--- a/test/uri.js
+++ b/test/uri.js
@@ -255,4 +255,17 @@ describe('Uri', function() {
     u = new Uri('http://username:password@example.com:8080/username@email.com/page')
     assert.equal(u.port(), '8080')
   })
+
+  it('Should be able to match query param keys as case insensitive', function () {
+    u = new Uri('http://example.com/search?qI=a&qi=a').caseSensitive(false)
+    assert.equal(u.getQueryParamValue('qi'), 'a')
+    assert.equal(u.getQueryParamValue('QI'), 'a')
+    assert.deepEqual(u.getQueryParamValues('QI'), ['a', 'a'])
+  })
+
+  // it('should be able delete query params when case insensitive', function() {
+  //   u = new Uri('http://example.com/search?q=a&stupid=yes').caseSensitive(false)
+  //   u.deleteQueryParam('stupId')
+  //   assert.equal(u.toString(), 'http://example.com/search?q=a')
+  // })
 })


### PR DESCRIPTION
Fixes #57.

This is basically what was requested in #57, it adds a setter, `.caseSensitive`. Have a look at the test case. Then when query param keys are being matched, it should take that into account.

Right now, only `getQueryParamValue` and `getQueryParamValues` are changed but I believed other places such as `deleteQueryParam`, `hasQueryParam` and `replaceQueryParam` should also be changed for consistent behavior.

@derek-watson Tell me what you think about this, if you think this method is OK, I'm going to complete this.