### PR TITLE
Added MIT License to package.json (Issue #71)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Uri and query string manipulation",
   "version": "1.3.1",
   "author": "Derek Watson <watson@dcw.ca> (http://dcw.ca)",
+  "license": "MIT",
   "contributors": [
     {
       "name": "James M. Greene",


### PR DESCRIPTION
As mentioned in issue #71 of the repository, I have added the MIT license in package.json